### PR TITLE
Pass options to read-installed

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ var util = require('util');
 
 exports.read = read;
 
-function read(where, callback) {
-  readInstalled(where, function(er, deps) {
+function read(where, opts, callback) {
+  readInstalled(where, opts, function(er, deps) {
     if (er) return callback(er);
 
     deps = stripCircular(deps);

--- a/test/test-read.js
+++ b/test/test-read.js
@@ -1,0 +1,33 @@
+path = require('path');
+assert = require('assert');
+var tap = require('tap');
+ls = require('../');
+
+function keys(obj) {
+  return Object.keys(obj || {});
+}
+
+tap.test('read with depth 0', function(t) {
+  t.plan(2);
+  var where = path.resolve(__dirname, 'deep-deps');
+
+  ls.read(where, {depth: 0}, function(er, json) {
+    assert.ifError(er);
+    
+    t.same(keys(json.dependencies), ['a']);
+    t.same(keys(json.dependencies.a.dependencies), []);
+  });
+});
+
+tap.test('read with depth 1', function(t) {
+  t.plan(3);
+  var where = path.resolve(__dirname, 'deep-deps');
+
+  ls.read(where, {depth: 1}, function(er, json) {
+    assert.ifError(er);
+    
+    t.same(keys(json.dependencies), ['a']);
+    t.same(keys(json.dependencies.a.dependencies), ['b']);
+    t.same(keys(json.dependencies.a.dependencies.b.dependencies), []);
+  });
+});


### PR DESCRIPTION
Today you can't pass options to `read-installed` when using `read` function. These options are sometimes useful (I personally need to be able to ask for `{depth: 0}`. I have pretty large dependency tree and if I don't limit depth at this point the `read` operation takes significantly longer).

This PR adds optional `opts` argument to read function.